### PR TITLE
fix: changed the oidc role name due to rename of jenkins

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -1,3 +1,3 @@
 module "common" {
-  source = "github.com/global-devops-terraform/global-info?ref=v0.34.0"
+  source = "github.com/global-devops-terraform/global-info?ref=v0.34.1"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,5 +8,5 @@ module "jenkins" {
   source = "github.com/global-devops-terraform/jenkins-roles?ref=v1.1.0"
 
   bucket_name  = module.terraform.bucket_name
-  jenkins_role = module.common.jenkins_oidc_roles["self-service"]
+  jenkins_role = module.common.jenkins_oidc_roles["selfservice"]
 }


### PR DESCRIPTION
# What?

Bumped the common module version due to change in jenkins name